### PR TITLE
Adjust styles to improve mobile experience

### DIFF
--- a/components/board.tsx
+++ b/components/board.tsx
@@ -24,7 +24,10 @@ export default function Board(props: Props) {
 
   async function onDragStart() {
     setIsDragging(true);
-    navigator.vibrate(20);
+
+    if ("vibrate" in navigator) {
+      navigator.vibrate(20);
+    }
   }
 
   async function onDragEnd(result: DropResult) {

--- a/styles/board.module.scss
+++ b/styles/board.module.scss
@@ -1,19 +1,21 @@
 .wrapper {
   display: grid;
-  grid-auto-columns: auto;
-  grid-template-rows: 350px auto;
+  grid-template-rows: 1fr auto;
+
   width: 100%;
   height: 100%;
 }
 
 .top {
-  grid-row: 1;
+  display: grid;
+  place-content: center;
 }
 
 .bottom {
-  grid-row: 2;
-  overflow-x: auto;
   display: flex;
   align-items: center;
+
   position: relative;
+  overflow-x: auto;
+  padding: 0 0 3rem 0;
 }

--- a/styles/board.module.scss
+++ b/styles/board.module.scss
@@ -1,6 +1,6 @@
 .wrapper {
   display: grid;
-  grid-template-rows: 1fr auto;
+  grid-template-rows: 350px auto;
 
   width: 100%;
   height: 100%;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -20,6 +20,8 @@ body,
 }
 
 body {
+  overflow: hidden;
+  height: 100vh;
   overscroll-behavior-y: contain;
 }
 

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -22,7 +22,6 @@ body,
 body {
   overflow: hidden;
   height: 100vh;
-  overscroll-behavior-y: contain;
 
   // Account for mobile Safari UI
   // https://www.bram.us/2020/05/06/100vh-in-safari-on-ios/

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -23,6 +23,12 @@ body {
   overflow: hidden;
   height: 100vh;
   overscroll-behavior-y: contain;
+
+  // Account for mobile Safari UI
+  // https://www.bram.us/2020/05/06/100vh-in-safari-on-ios/
+  @supports (-webkit-touch-callout: none) {
+    height: -webkit-fill-available;
+  }
 }
 
 a {

--- a/styles/item-card.module.scss
+++ b/styles/item-card.module.scss
@@ -23,6 +23,7 @@
       rgba(0, 0, 0, 0.23) 0px 6px 6px;
     background-color: #ffffff;
     will-change: transform, opacity;
+    pointer-events: none;
 
     &::after {
       content: "";


### PR DESCRIPTION
This PR makes the game easier to play on mobile:
- Dragging question cards starts immediately (because touch events from child elements are now ignored). Addresses https://github.com/tom-james-watson/wikitrivia/issues/40
- Bouncy over-scrolling is prevented by constraining viewport height