### PR TITLE
Makes dates increase in difficulty, keeping them 5 years apart at all times

### DIFF
--- a/lib/items.ts
+++ b/lib/items.ts
@@ -10,8 +10,12 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   const [fromYear, toYear] =
     periods[Math.floor(Math.random() * periods.length)];
   const avoidPeople = Math.random() > 0.5;
-  let distance = 110 - 10 * played.length;
-  distance = distance < 5 ? 5 : distance;
+  let distance = 5;
+  if (played.length < 11) { 
+    distance = 110 - 10 * played.length;
+  } else if (played.length > 40) {
+    distance = 1;
+  }
   let item = deck[Math.floor(Math.random() * deck.length)];
 
   for (let i = 0; i < 10000; i++) {

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -18,7 +18,7 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
       return false;
     }
 
-    if (candidate.year < fromYear || candidate.year > toYear) {
+    if (played.length < 40 && (candidate.year < fromYear || candidate.year > toYear)) {
       return false;
     }
 

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -26,7 +26,6 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   if (candidates.length > 0) {
     return candidates[Math.floor(Math.random() * candidates.length)];
   }
-  throw new Error("No item candidates");
   return deck[Math.floor(Math.random() * deck.length)];
 }
 
@@ -35,12 +34,7 @@ function tooClose(item: Item, played: Item[]) {
   if (played.length < 11)
     distance = 110 - 10 * played.length;
 
-  for (let j = 0; j < played.length; j++) {
-    if (Math.abs(item.year - played[j].year) < distance) {
-      return true;
-    }
-  }
-  return false;
+  return played.some((p) => Math.abs(item.year - p.year) < distance);
 }
 
 export function checkCorrect(

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -31,11 +31,12 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
     return true;
   });
 
-  if (candidates.length === 0) {
+  if (candidates.length > 0) {
+    const item = { ...candidates[Math.floor(Math.random() * candidates.length)] };
+  } else {
     throw new Error("No item candidates");
+    const item = { ...deck[Math.floor(Math.random() * deck.length)] };
   }
-
-  const item = { ...candidates[Math.floor(Math.random() * candidates.length)] };
 
   return item;
 }

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -24,7 +24,7 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
     }
 
     for (let i = 0; i < played.length; i++) {
-      if (Math.abs(candidate.year - played.year) < distance) {
+      if (Math.abs(candidate.year - played[i].year) < distance) {
         return false;
       }
     }

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -22,15 +22,22 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
     if (item.year < fromYear || item.year > toYear) {
       continue;
     }
-    for (let j = 0; j < played.length; j++) {
-      if (Math.abs(item.year - played[j].year) < distance) {
-        continue;
-      }
+    if (tooClose(item, played, distance)) {
+      continue;
     }
     return item;
   }
 
   return item;
+}
+
+function tooClose(item, played, distance) {
+  for (let j = 0; j < played.length; j++) {
+    if (Math.abs(item.year - played[j].year) < distance) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function checkCorrect(

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -11,7 +11,7 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   const [fromYear, toYear] =
     periods[Math.floor(Math.random() * periods.length)];
   const avoidPeople = Math.random() > 0.5;
-  let distance = 100 - 10 * played.length;
+  let distance = 110 - 10 * played.length;
   distance = distance < 5 ? 5 : distance;
 
   const candidates = deck.filter((candidate) => {

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -2,24 +2,12 @@ import { Item, PlayedItem } from "../types/item";
 import { createWikimediaImage } from "./image";
 
 export function getRandomItem(deck: Item[], played: Item[]): Item {
-  const periods: [number, number][] = [
-    [-100000, 1400],
-    [1400, 1850],
-    [1850, 1930],
-    [1930, 2020],
-  ];
-  const [fromYear, toYear] =
-    periods[Math.floor(Math.random() * periods.length)];
   const avoidPeople = Math.random() > 0.5;
   let distance = 110 - 10 * played.length;
   distance = distance < 5 ? 5 : distance;
 
   const candidates = deck.filter((candidate) => {
     if (avoidPeople && candidate.instance_of.includes("human")) {
-      return false;
-    }
-
-    if (candidate.year < fromYear || candidate.year > toYear) {
       return false;
     }
 

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -2,12 +2,23 @@ import { Item, PlayedItem } from "../types/item";
 import { createWikimediaImage } from "./image";
 
 export function getRandomItem(deck: Item[], played: Item[]): Item {
+  const periods: [number, number][] = [
+    [-100000, 1000],
+    [1000, 1800],
+    [1800, 2020],
+  ];
+  const [fromYear, toYear] =
+    periods[Math.floor(Math.random() * periods.length)];
   const avoidPeople = Math.random() > 0.5;
   let distance = 110 - 10 * played.length;
   distance = distance < 5 ? 5 : distance;
 
   const candidates = deck.filter((candidate) => {
     if (avoidPeople && candidate.instance_of.includes("human")) {
+      return false;
+    }
+
+    if (candidate.year < fromYear || candidate.year > toYear) {
       return false;
     }
 

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -24,12 +24,10 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   });
 
   if (candidates.length > 0) {
-    const item = { ...candidates[Math.floor(Math.random() * candidates.length)] };
-  } else {
-    throw new Error("No item candidates");
-    const item = { ...deck[Math.floor(Math.random() * deck.length)] };
+    return candidates[Math.floor(Math.random() * candidates.length)];
   }
-  return item;
+  throw new Error("No item candidates");
+  return deck[Math.floor(Math.random() * deck.length)];
 }
 
 function tooClose(item: Item, played: Item[]) {

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -12,30 +12,22 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   const avoidPeople = Math.random() > 0.5;
   let distance = 110 - 10 * played.length;
   distance = distance < 5 ? 5 : distance;
+  let item;
 
-  const candidates = deck.filter((candidate) => {
+  for (let i = 0; i < 1000; i++) {
+    item = deck[Math.floor(Math.random() * deck.length)];
     if (avoidPeople && candidate.instance_of.includes("human")) {
-      return false;
+      continue;
     }
-
-    if (played.length < 40 && (candidate.year < fromYear || candidate.year > toYear)) {
-      return false;
+    if (candidate.year < fromYear || candidate.year > toYear) {
+      continue;
     }
-
-    for (let i = 0; i < played.length; i++) {
-      if (Math.abs(candidate.year - played[i].year) < distance) {
-        return false;
+    for (let j = 0; j < played.length; j++) {
+      if (Math.abs(candidate.year - played[j].year) < distance) {
+        continue;
       }
     }
-
-    return true;
-  });
-
-  if (candidates.length > 0) {
-    const item = { ...candidates[Math.floor(Math.random() * candidates.length)] };
-  } else {
-    throw new Error("No item candidates");
-    const item = { ...deck[Math.floor(Math.random() * deck.length)] };
+    return item;
   }
 
   return item;

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -12,7 +12,7 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   const avoidPeople = Math.random() > 0.5;
   let distance = 110 - 10 * played.length;
   distance = distance < 5 ? 5 : distance;
-  let item;
+  let item = deck[Math.floor(Math.random() * deck.length)];
 
   for (let i = 0; i < 10000; i++) {
     item = deck[Math.floor(Math.random() * deck.length)];

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -2,10 +2,6 @@ import { Item, PlayedItem } from "../types/item";
 import { createWikimediaImage } from "./image";
 
 export function getRandomItem(deck: Item[], played: Item[]): Item {
-  const playedYears = played.map((item): number => {
-    return item.year;
-  });
-
   const periods: [number, number][] = [
     [-100000, 1400],
     [1400, 1850],
@@ -15,6 +11,8 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   const [fromYear, toYear] =
     periods[Math.floor(Math.random() * periods.length)];
   const avoidPeople = Math.random() > 0.5;
+  let distance = 100 - 10 * played.length;
+  distance = distance < 5 ? 5 : distance;
 
   const candidates = deck.filter((candidate) => {
     if (avoidPeople && candidate.instance_of.includes("human")) {
@@ -25,8 +23,10 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
       return false;
     }
 
-    if (playedYears.includes(candidate.year)) {
-      return false;
+    for (let i = 0; i < played.length; i++) {
+      if (Math.abs(candidate.year - played.year) < distance) {
+        return false;
+      }
     }
 
     return true;

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -14,16 +14,16 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   distance = distance < 5 ? 5 : distance;
   let item;
 
-  for (let i = 0; i < 1000; i++) {
+  for (let i = 0; i < 10000; i++) {
     item = deck[Math.floor(Math.random() * deck.length)];
-    if (avoidPeople && candidate.instance_of.includes("human")) {
+    if (avoidPeople && item.instance_of.includes("human")) {
       continue;
     }
-    if (candidate.year < fromYear || candidate.year > toYear) {
+    if (item.year < fromYear || item.year > toYear) {
       continue;
     }
     for (let j = 0; j < played.length; j++) {
-      if (Math.abs(candidate.year - played[j].year) < distance) {
+      if (Math.abs(item.year - played[j].year) < distance) {
         continue;
       }
     }

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -31,7 +31,7 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
   return item;
 }
 
-function tooClose(item, played, distance) {
+function tooClose(item: Item, played: Item[], distance: number) {
   for (let j = 0; j < played.length; j++) {
     if (Math.abs(item.year - played[j].year) < distance) {
       return true;

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -54,7 +54,7 @@ export function checkCorrect(
     return i.id === item.id;
   });
 
-  if (index !== correctIndex) {
+  if (index !== correctIndex && item.year !== [...played, item][correctIndex].year) {
     return { correct: false, delta: correctIndex - index };
   }
 


### PR DESCRIPTION
I believe this addresses #19 and #8 (though there was code for #8 in there already) by requiring the first two cards are 100 years apart, then 90, 80, 70, ... 20, 10, and finally 5 for the rest of the game.  (i.e., it never allows the cards to be closer than 5 years together.)

The loop that compares the dates is more processor intensive of course, but I think it should still be pretty fast.