### PR TITLE
Add Corsica

### DIFF
--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -87,6 +87,7 @@ const badCards = {
   Q2001966: "Company rule in India",
   Q2723024: "Enron scandal",
   Q133600: "Banksy",
+  Q14112: "Corsica",
 };
 
 export default badCards;


### PR DESCRIPTION
Corsica showing date as 1972 - can find no reference for this on Wikipedia (there was a park created in 1972 which may be what is being pulled).