### PR TITLE
Salvator Mundi with "circa" date

### DIFF
--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -87,6 +87,7 @@ const badCards = {
   Q2001966: "Company rule in India",
   Q2723024: "Enron scandal",
   Q133600: "Banksy",
+  Q1892745: "Salvator Mundi (Leonardo)"
 };
 
 export default badCards;


### PR DESCRIPTION
The wikipedia article states this painting to be circa 1499-1510, but the card has 1490. Either the card should be removed, support for date ranges should be added, or an average of the circa dates should be used.