### PR TITLE
Remove Brutalist architecture

### DIFF
--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -87,6 +87,7 @@ const badCards = {
   Q2001966: "Company rule in India",
   Q2723024: "Enron scandal",
   Q133600: "Banksy",
+  Q546359: "Brutalist architecture"
 };
 
 export default badCards;


### PR DESCRIPTION
This movement doesn't have a specific start or end date, especially since there are a lot of cards in the 1900s. Also the end date does not match the wikipedia article.