### PR TITLE
Add Pelagius to bad cards

### DIFF
--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -87,6 +87,7 @@ const badCards = {
   Q2001966: "Company rule in India",
   Q2723024: "Enron scandal",
   Q133600: "Banksy",
+  Q162593: "Pelagius",
 };
 
 export default badCards;


### PR DESCRIPTION
His card has a spoiler in it, because it says he's a 4th-century theologian.