### PR TITLE
Fixes Afghanistan issue and others: 7cf401e

### DIFF
--- a/components/game.tsx
+++ b/components/game.tsx
@@ -26,7 +26,8 @@ export default function Game() {
           return JSON.parse(line);
         })
         // Filter out questions which give away their answers
-        .filter((item) => !item.label.includes(String(item.year)))
+        .filter((item) => !item.label.includes(String(item.year))
+        .filter((item) => !item.label.includes("present" || "th century")
         // Filter cards which have bad data as submitted in https://github.com/tom-james-watson/wikitrivia/discussions/2
         .filter((item) => !(item.id in badCards));
       setItems(items);


### PR DESCRIPTION
Removes cards that have "present" in their name or "th century" to be able to filter out cards that have their answers in the title.