### PR TITLE
FIxes Afghanistan issue and others: 7cf401e

### DIFF
--- a/components/game.tsx
+++ b/components/game.tsx
@@ -26,7 +26,7 @@ export default function Game() {
           return JSON.parse(line);
         })
         // Filter out questions which give away their answers
-        .filter((item) => !item.label.includes(String(item.year)))
+        .filter((item) => !item.label.includes((String(item.year)) || "present" || "th century"))
         // Filter cards which have bad data as submitted in https://github.com/tom-james-watson/wikitrivia/discussions/2
         .filter((item) => !(item.id in badCards));
       setItems(items);


### PR DESCRIPTION
This would filter out cards that have "present" and "th century" in the title so that cards that give away the answer in the title can be filtered out.