### PR TITLE
remove St Michael's Mount

### DIFF
--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -111,7 +111,8 @@ const badCards = {
   Q3916703: "Riley Reid",
   Q18749736: "Johnny Sins",
   Q65115154: "Belle Delphine",
-  Q739550: "M&M's"
+  Q739550: "M&M's",
+  Q1431121: "St Michael's Mount"
 };
 
 export default badCards;


### PR DESCRIPTION
This card has an inception date of 1135 AD, which is nonsense. The Wikipedia page talks about evidence of human life from thousands of years BC, and surely the island itself was formed millions of years ago.

* https://www.wikidata.org/wiki/Q1431121
* https://en.wikipedia.org/wiki/St_Michael%27s_Mount