### PR TITLE
Remove Hogwarts

### DIFF
--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -113,6 +113,7 @@ const badCards = {
   Q65115154: "Belle Delphine",
   Q739550: "M&M's",
   Q1431121: "St Michael's Mount"
+  Q174097: "Hogwarts"
 };
 
 export default badCards;

--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -112,7 +112,7 @@ const badCards = {
   Q18749736: "Johnny Sins",
   Q65115154: "Belle Delphine",
   Q739550: "M&M's",
-  Q1431121: "St Michael's Mount"
+  Q1431121: "St Michael's Mount",
   Q174097: "Hogwarts"
 };
 


### PR DESCRIPTION
As a fictional location, its date of 'creation' is not really the 10th century, which defaults to the year 1000. This is confusing, and the card should be removed. I think the game is pulling from Q174097, but it could also be pulling from "Hogwarts Castle" which is Q27924622