### PR TITLE
Updating bad-cards.ts to exclude Homicide

### DIFF
--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -114,7 +114,8 @@ const badCards = {
   Q739550: "M&M's",
   Q1431121: "St Michael's Mount",
   Q174097: "Hogwarts",
-  Q8690: "Cultural Revolution"
+  Q8690: "Cultural Revolution",
+  Q149086: "Homicide"
 };
 
 export default badCards;


### PR DESCRIPTION
Updating bad-cards to exclude the concept of Homicide. While the earlier known writing about Murder/Homicide is Hammurabi's code (1752 BC), the concept of homicide (as depicted in the card) would likely be Cain and Abel (also depicted in the wiki preview from an art), around 4000BC.