### PR TITLE
added Longinus and Lazarus to badCards

### DIFF
--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -115,7 +115,8 @@ const badCards = {
   Q1431121: "St Michael's Mount",
   Q174097: "Hogwarts",
   Q8690: "Cultural Revolution",
-  Q149086: "Homicide"
+  Q149086: "Homicide",
+  Q319947: "Longinus"
 };
 
 export default badCards;

--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -117,6 +117,7 @@ const badCards = {
   Q8690: "Cultural Revolution",
   Q149086: "Homicide",
   Q319947: "Longinus"
+  Q539890: "Lazarus of Bethany"
 };
 
 export default badCards;

--- a/lib/bad-cards.ts
+++ b/lib/bad-cards.ts
@@ -116,7 +116,7 @@ const badCards = {
   Q174097: "Hogwarts",
   Q8690: "Cultural Revolution",
   Q149086: "Homicide",
-  Q319947: "Longinus"
+  Q319947: "Longinus",
   Q539890: "Lazarus of Bethany"
 };
 


### PR DESCRIPTION
Longinus is the soldier said to have pierce the side of Jesus during the crucifixion. Per Wikidata, he is believed to have both been born and to have died in the first century CE, but the game interprets his birth date as 100 CE. Definitely incorrect.