### PR TITLE
Allow any number of hearts and stop duplicate cards

### DIFF
--- a/components/hearts.tsx
+++ b/components/hearts.tsx
@@ -34,11 +34,14 @@ interface Props {
 export default function Hearts(props: Props) {
   const { lives } = props;
 
+  const elements: JSX.Element[] = [];
+  for (let counter = 1; counter <= lives; counter++) {
+      elements.push(<Heart have={lives >= counter} />);
+  }
+
   return (
     <div className={styles.hearts}>
-      <Heart have={lives >= 1} />
-      <Heart have={lives >= 2} />
-      <Heart have={lives >= 3} />
+      {elements}
     </div>
   );
 }

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -20,6 +20,11 @@ export function getRandomItem(deck: Item[], played: Item[]): Item {
     if (tooClose(candidate, played)) {
       return false;
     }
+    for (const playedItem of played) {
+      if (playedItem.id === candidate.id) {
+        return false;
+      }
+    }
     return true;
   });
 


### PR DESCRIPTION
- Updated the creation of the hearts to create the number of hearts based off the lives
- Fixed getRandomItem to stop duplicate cards appearing. Although I'm think this may already be sorted by the tooClose method before? I added this after making some changes in my fork to use local data to create a small Christmas game. I removed the tooClose check as the values were only from 1-100 so much more likely to be very close.