### PR TITLE
Center align score

### DIFF
--- a/styles/score.module.scss
+++ b/styles/score.module.scss
@@ -15,7 +15,7 @@
   }
 
   .value {
-    display: flex;
+    text-align: center;
     font-weight: 700;
     font-size: 24px;
   }


### PR DESCRIPTION
It looks better to me:

**Before:**
![Capture d’écran du 2024-03-10 13-26-03](https://github.com/tom-james-watson/wikitrivia/assets/930064/9e5e3dbd-759e-4ed0-b9fc-83244d689e42)

**After:**
![Capture d’écran du 2024-03-10 13-25-50](https://github.com/tom-james-watson/wikitrivia/assets/930064/bd4081a1-c467-43dc-b000-a054c8cdd67f)

**Before:**
![Capture d’écran du 2024-03-10 13-25-02](https://github.com/tom-james-watson/wikitrivia/assets/930064/f47599e7-5d58-4212-add0-9b0f06ca6dd8)

**After:**
![Capture d’écran du 2024-03-10 13-25-32](https://github.com/tom-james-watson/wikitrivia/assets/930064/a3bfe0cc-6347-4251-9503-e1268246ecdc)

