### PR TITLE
Century hints removed as intended

### DIFF
--- a/components/game.tsx
+++ b/components/game.tsx
@@ -12,7 +12,7 @@ export default function Game() {
   const [state, setState] = useState<GameState | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [started, setStarted] = useState(false);
-  const [items, setItems] = useState<Item[] | null>(null);
+  const [items, setItems] = useState<Item[] | null>(null); 
 
   React.useEffect(() => {
     const fetchGameData = async () => {
@@ -28,9 +28,7 @@ export default function Game() {
         // Filter out questions which give away their answers
         .filter((item) => !item.label.includes(String(item.year)))
         .filter((item) => !item.description.includes(String(item.year)))
-        .filter((item) => !item.description.includes(String("st century")))
-        .filter((item) => !item.description.includes(String("nd century")))
-        .filter((item) => !item.description.includes(String("th century")))
+        .filter((item) => !/(?:th|st|nd)[ -]century/.test(item.description))
         // Filter cards which have bad data as submitted in https://github.com/tom-james-watson/wikitrivia/discussions/2
         .filter((item) => !(item.id in badCards));
       setItems(items);

--- a/components/game.tsx
+++ b/components/game.tsx
@@ -28,7 +28,7 @@ export default function Game() {
         // Filter out questions which give away their answers
         .filter((item) => !item.label.includes(String(item.year)))
         .filter((item) => !item.description.includes(String(item.year)))
-        .filter((item) => !/(?:th|st|nd)[ -]century/.test(item.description))
+        .filter((item) => !/(?:th|st|nd)[ -]century/i.test(item.description))
         // Filter cards which have bad data as submitted in https://github.com/tom-james-watson/wikitrivia/discussions/2
         .filter((item) => !(item.id in badCards));
       setItems(items);

--- a/components/game.tsx
+++ b/components/game.tsx
@@ -28,7 +28,9 @@ export default function Game() {
         // Filter out questions which give away their answers
         .filter((item) => !item.label.includes(String(item.year)))
         .filter((item) => !item.description.includes(String(item.year)))
-        .filter((item) => !item.description.includes(String("st century" || "nd century" || "th century")))
+        .filter((item) => !item.description.includes(String("st century")))
+        .filter((item) => !item.description.includes(String("nd century")))
+        .filter((item) => !item.description.includes(String("th century")))
         // Filter cards which have bad data as submitted in https://github.com/tom-james-watson/wikitrivia/discussions/2
         .filter((item) => !(item.id in badCards));
       setItems(items);


### PR DESCRIPTION
Previous code had a bug where only "st century" would get blocked. This also blocks "nd century" and "th century" as intended.

The bugged code can be checked in a console:
```
>> "2nd century Greek bishop and saint".includes(String("st century") || String("nd century") || String("th century"))
<- false
>> "1st century AD tetrarch of Galilee and Perea".includes(String("st century") || String("nd century") || String("th century")) 
<- true
```

Some descriptions also have hyphens instead of spaces, so I remove those as well.