### PR TITLE
Prevents the str.charAt crash

### DIFF
--- a/components/item-card.tsx
+++ b/components/item-card.tsx
@@ -60,7 +60,7 @@ export default function ItemCard(props: Props) {
       return item.occupations[0];
     }
 
-    return item.instance_of[0];
+    return item.instance_of[0] ?? "";
   }, [item]);
 
   return (


### PR DESCRIPTION
Game will periodically crash with a mysterious `str.charAt` error in the capitalize function. Mentioned in a comment in #95 though may not have been OP's problem.

One cause is in the type memo in `item-card.tsx`. It should always return a string, but in some cases returns undefined.

Punic Wars, for example, has a >60 character description, and is not a human, so it attempts to return the first element of its instance_of array, but the array is empty.